### PR TITLE
feature/calendar-page-ui | feat: 캘린더 페이지 UI 생성

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import MainContent from './components/MainContent';
 import HomeScreen from './components/HomeScreen';
 import MovieRecommendation from './components/MovieRecommendation';
 import MovieDetail from './components/MovieDetail';
+import Calendar from './components/Calendar';
 import { useMood } from './hooks/useMood';
 import { useAuth } from './hooks/useAuth';
 
@@ -16,7 +17,7 @@ function App() {
     handleGoHome
   } = useMood();
   
-  const [currentView, setCurrentView] = useState('main'); // 'main', 'recommendation', 'detail'
+  const [currentView, setCurrentView] = useState('main'); // 'main', 'recommendation', 'calendar', 'detail'
   const [selectedMovie, setSelectedMovie] = useState(null);
   const [previousView, setPreviousView] = useState('main');
 
@@ -32,6 +33,10 @@ function App() {
 
   const handleShowRecommendation = () => {
     setCurrentView('recommendation');
+  };
+
+  const handleShowCalendar = () => {
+    setCurrentView('calendar');
   };
 
   const handleBackToMain = () => {
@@ -62,12 +67,15 @@ function App() {
           <Sidebar 
             onPlusClick={handleShowRecommendation} 
             onHomeClick={handleGoToHome}
+            onCalendarClick={handleShowCalendar}
             currentView={currentView}
           />
           {currentView === 'main' ? (
             <MainContent onMovieClick={handleMovieClick} />
           ) : currentView === 'recommendation' ? (
             <MovieRecommendation onBack={handleBackToMain} onMovieClick={handleMovieClick} />
+          ) : currentView === 'calendar' ? (
+            <Calendar onBack={handleBackToMain} />
           ) : (
             <MovieDetail movie={selectedMovie} onBack={handleBackFromDetail} />
           )}

--- a/src/components/Calendar.css
+++ b/src/components/Calendar.css
@@ -1,0 +1,525 @@
+.calendar-container {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+/* 기본 캘린더 팝업 */
+.calendar-popup {
+  background: white;
+  border-radius: 12px;
+  padding: 40px;
+  max-width: 800px;
+  width: 95%;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
+}
+
+.calendar-header {
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+.calendar-header {
+  position: relative;
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+.calendar-header h2 {
+  font-size: 32px;
+  font-weight: bold;
+  color: #333;
+  margin: 0;
+}
+
+.calendar-navigation {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+}
+
+.nav-btn {
+  background: none;
+  border: none;
+  font-size: 24px;
+  color: #333;
+  cursor: pointer;
+  padding: 8px 12px;
+  border-radius: 4px;
+  transition: background-color 0.2s ease;
+}
+
+.nav-btn:hover {
+  background-color: #f0f0f0;
+}
+
+.close-btn {
+  position: absolute;
+  top: -10px;
+  right: -10px;
+  width: 30px;
+  height: 30px;
+  border: none;
+  background-color: #dc3545;
+  color: white;
+  border-radius: 50%;
+  font-size: 18px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.2s ease;
+}
+
+.close-btn:hover {
+  background-color: #c82333;
+}
+
+.calendar-edit-header {
+  position: relative;
+  margin-bottom: 20px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.back-btn {
+  background-color: #6c757d;
+  color: white;
+  border: none;
+  padding: 8px 16px;
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: bold;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.back-btn:hover {
+  background-color: #5a6268;
+}
+
+.calendar-grid {
+  margin-bottom: 20px;
+}
+
+.calendar-weekdays {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 8px;
+  margin-bottom: 15px;
+}
+
+.calendar-weekdays span {
+  text-align: center;
+  font-weight: bold;
+  color: #333;
+  padding: 15px 8px;
+  font-size: 16px;
+}
+
+.calendar-days {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 8px;
+}
+
+.calendar-day {
+  aspect-ratio: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  cursor: pointer;
+  position: relative;
+  transition: all 0.2s ease;
+}
+
+.calendar-day.empty {
+  cursor: default;
+}
+
+.calendar-day.has-content:hover {
+  background-color: #f0f0f0;
+}
+
+.calendar-day.has-mood {
+  background-color: #fff3cd;
+  border: 2px solid #ffc107;
+}
+
+.calendar-day.has-entry {
+  background-color: #e3f2fd;
+  border: 2px solid #2196f3;
+}
+
+.calendar-day.selected {
+  background-color: #2196f3;
+  color: white;
+}
+
+.calendar-day.selected .day-number {
+  color: white;
+}
+
+.day-number {
+  font-size: 20px;
+  font-weight: 500;
+  color: #333;
+}
+
+.mood-indicator {
+  position: absolute;
+  bottom: 2px;
+  right: 2px;
+  font-size: 12px;
+}
+
+.edit-calendar-btn {
+  width: 100%;
+  background-color: #dc3545;
+  color: white;
+  border: none;
+  padding: 16px;
+  border-radius: 8px;
+  font-size: 18px;
+  font-weight: bold;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.edit-calendar-btn:hover {
+  background-color: #c82333;
+}
+
+/* 편집 모드 캘린더 팝업 */
+.calendar-edit-popup {
+  background: white;
+  border-radius: 12px;
+  padding: 30px;
+  max-width: 1200px;
+  width: 95%;
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
+}
+
+.calendar-edit-content {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 30px;
+  margin-bottom: 20px;
+}
+
+/* 왼쪽 패널 */
+.calendar-left-panel {
+  background-color: #f8f9fa;
+  padding: 20px;
+  border-radius: 8px;
+}
+
+.calendar-left-panel h3 {
+  margin: 0 0 20px 0;
+  font-size: 18px;
+  font-weight: bold;
+  color: #333;
+}
+
+.profile-section {
+  margin-bottom: 20px;
+}
+
+.profile-placeholder {
+  width: 80px;
+  height: 80px;
+  background-color: #ddd;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #666;
+  font-size: 12px;
+}
+
+.recommended-movies h4 {
+  margin: 0 0 15px 0;
+  font-size: 14px;
+  color: #333;
+}
+
+.movie-poster-placeholder {
+  width: 100%;
+  height: 120px;
+  background-color: #ddd;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #666;
+  font-size: 12px;
+  margin-bottom: 15px;
+}
+
+.movie-description {
+  margin-top: 15px;
+}
+
+.movie-description p {
+  margin: 0 0 8px 0;
+  font-size: 12px;
+  color: #666;
+  line-height: 1.4;
+}
+
+/* 중앙 패널 */
+.calendar-center-panel {
+  padding: 20px;
+}
+
+.calendar-center-panel h3 {
+  margin: 0 0 10px 0;
+  font-size: 18px;
+  font-weight: bold;
+  color: #333;
+}
+
+.calendar-center-panel p {
+  margin: 0 0 20px 0;
+  color: #666;
+  font-size: 14px;
+}
+
+.calendar-month-navigation {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 15px;
+  margin-bottom: 20px;
+}
+
+.calendar-month-navigation p {
+  margin: 0;
+  font-size: 16px;
+  font-weight: bold;
+  color: #333;
+}
+
+/* 오른쪽 패널 */
+.calendar-right-panel {
+  padding: 20px;
+  background-color: #f8f9fa;
+  border-radius: 8px;
+}
+
+.calendar-right-panel h3 {
+  margin: 0 0 10px 0;
+  font-size: 18px;
+  font-weight: bold;
+  color: #333;
+}
+
+.calendar-right-panel p {
+  margin: 0 0 20px 0;
+  color: #666;
+  font-size: 14px;
+}
+
+.mood-selection h4 {
+  margin: 0 0 15px 0;
+  font-size: 16px;
+  color: #333;
+}
+
+.mood-options {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 20px;
+}
+
+.mood-option {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px;
+  border: 2px solid #ddd;
+  border-radius: 8px;
+  background: white;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.mood-option:hover {
+  border-color: #2196f3;
+}
+
+.mood-option.selected {
+  border-color: #2196f3;
+  background-color: #e3f2fd;
+}
+
+.mood-emoji {
+  font-size: 20px;
+}
+
+.mood-text {
+  font-size: 14px;
+  color: #333;
+}
+
+.notes-section h4 {
+  margin: 0 0 15px 0;
+  font-size: 16px;
+  color: #333;
+}
+
+.notes-textarea {
+  width: 100%;
+  min-height: 100px;
+  padding: 12px;
+  border: 2px solid #ddd;
+  border-radius: 8px;
+  resize: vertical;
+  font-family: inherit;
+  font-size: 14px;
+}
+
+.notes-textarea:focus {
+  outline: none;
+  border-color: #2196f3;
+}
+
+.save-btn {
+  width: 100%;
+  background-color: #6c757d;
+  color: white;
+  border: none;
+  padding: 12px;
+  border-radius: 8px;
+  font-size: 16px;
+  font-weight: bold;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+  margin-top: 15px;
+}
+
+.save-btn:hover {
+  background-color: #5a6268;
+}
+
+.button-group {
+  display: flex;
+  gap: 10px;
+  margin-top: 15px;
+}
+
+.button-group .save-btn {
+  flex: 1;
+  margin-top: 0;
+}
+
+.delete-btn {
+  flex: 1;
+  background-color: #dc3545;
+  color: white;
+  border: none;
+  padding: 12px;
+  border-radius: 8px;
+  font-size: 16px;
+  font-weight: bold;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.delete-btn:hover {
+  background-color: #c82333;
+}
+
+.delete-btn:disabled {
+  background-color: #6c757d;
+  cursor: not-allowed;
+}
+
+.edit-complete-btn {
+  width: 100%;
+  background-color: #dc3545;
+  color: white;
+  border: none;
+  padding: 12px;
+  border-radius: 8px;
+  font-size: 16px;
+  font-weight: bold;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.edit-complete-btn:hover {
+  background-color: #c82333;
+}
+
+/* 로딩 및 에러 상태 */
+.loading-container,
+.error-container {
+  text-align: center;
+  padding: 40px;
+}
+
+.loading-spinner {
+  width: 40px;
+  height: 40px;
+  border: 4px solid #f3f3f3;
+  border-top: 4px solid #dc3545;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin: 0 auto 20px;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
+.error-message {
+  color: #dc3545;
+  margin-bottom: 20px;
+  font-size: 16px;
+}
+
+.retry-button {
+  background-color: #dc3545;
+  color: white;
+  border: none;
+  padding: 12px 24px;
+  border-radius: 8px;
+  font-size: 16px;
+  font-weight: bold;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.retry-button:hover {
+  background-color: #c82333;
+}
+
+/* 반응형 디자인 */
+@media (max-width: 768px) {
+  .calendar-edit-content {
+    grid-template-columns: 1fr;
+    gap: 20px;
+  }
+  
+  .calendar-popup,
+  .calendar-edit-popup {
+    padding: 20px;
+    margin: 20px;
+  }
+}

--- a/src/components/Calendar.css
+++ b/src/components/Calendar.css
@@ -22,11 +22,6 @@
 }
 
 .calendar-header {
-  text-align: center;
-  margin-bottom: 20px;
-}
-
-.calendar-header {
   position: relative;
   text-align: center;
   margin-bottom: 20px;

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -125,24 +125,17 @@ const Calendar = ({ onBack }) => {
   // 로딩 상태 플래그 (데이터 조회 시에만 전역 오버레이)
   const showGlobalLoading = loading && !isEditMode;
   
-  // 전역 로딩 상태 (데이터 조회 시에만)
-  if (showGlobalLoading) {
-    return (
-      <div className="calendar-container">
+  return (
+    <div className="calendar-container">
+      {showGlobalLoading && (
         <div className="calendar-popup">
           <div className="loading-container">
             <div className="loading-spinner"></div>
             <p>캘린더 데이터를 불러오는 중...</p>
           </div>
         </div>
-      </div>
-    );
-  }
-
-  // 에러 상태
-  if (error) {
-    return (
-      <div className="calendar-container">
+      )}
+      {error && (
         <div className="calendar-popup">
           <div className="error-container">
             <p className="error-message">{error}</p>
@@ -151,118 +144,21 @@ const Calendar = ({ onBack }) => {
             </button>
           </div>
         </div>
-      </div>
-    );
-  }
-
-  return (
-    <div className="calendar-container">
-      {!isEditMode ? (
-        // 기본 캘린더 뷰
-        <div className="calendar-popup">
-          <div className="calendar-header">
-            <button className="close-btn" onClick={onBack}>×</button>
-            <div className="calendar-navigation">
-              <button className="nav-btn" onClick={goToPreviousMonth}>‹</button>
-              <h2>{`${displayMonth + 1}월 ${displayYear}`}</h2>
-              <button className="nav-btn" onClick={goToNextMonth}>›</button>
-            </div>
-          </div>
-          <div className="calendar-grid">
-            <div className="calendar-weekdays">
-              <span>일</span>
-              <span>월</span>
-              <span>화</span>
-              <span>수</span>
-              <span>목</span>
-              <span>금</span>
-              <span>토</span>
-            </div>
-            <div className="calendar-days">
-              {calendarDays.map((day, index) => {
-                const hasEntry = daysWithEntries.includes(day);
-                const entry = hasEntry ? monthData.find(e => e.day === day) : null;
-                
-                return (
-                  <div
-                    key={index}
-                    className={`calendar-day ${day ? 'has-content' : 'empty'} ${hasEntry ? 'has-mood' : ''}`}
-                    onClick={() => handleDateClick(day)}
-                  >
-                    {day && (
-                      <>
-                        <span className="day-number">{day}</span>
-                        {hasEntry && (
-                          <span className="mood-indicator">
-                            {moods.find(m => m.text === entry.mood)?.emoji || '😊'}
-                          </span>
-                        )}
-                      </>
-                    )}
-                  </div>
-                );
-              })}
-            </div>
-          </div>
-          <button className="edit-calendar-btn" onClick={() => setIsEditMode(true)}>
-            캘린더 수정
-          </button>
-        </div>
-      ) : (
-        // 편집 모드 캘린더 뷰
-        <div className="calendar-edit-popup">
-          {/* 편집 모드에서 저장/삭제 중일 때만 로딩 오버레이 */}
-          {isLoading && (
-            <div className="loading-container" style={{
-              position: 'absolute',
-              top: 0,
-              left: 0,
-              right: 0,
-              bottom: 0,
-              background: 'rgba(255, 255, 255, 0.9)',
-              display: 'flex',
-              flexDirection: 'column',
-              justifyContent: 'center',
-              alignItems: 'center',
-              zIndex: 10,
-              borderRadius: '12px'
-            }}>
-              <div className="loading-spinner"></div>
-              <p>저장 중...</p>
-            </div>
-          )}
-          <div className="calendar-edit-header">
-            <button className="back-btn" onClick={() => setIsEditMode(false)}>← 뒤로가기</button>
-            <button className="close-btn" onClick={onBack}>×</button>
-          </div>
-          <div className="calendar-edit-content">
-            {/* 왼쪽 패널 - 나만의 캘린더 */}
-            <div className="calendar-left-panel">
-              <h3>나만의 캘린더</h3>
-              <div className="profile-section">
-                <div className="profile-placeholder">프로필</div>
+      )}
+      {!showGlobalLoading && !error && (
+        <>
+          {!isEditMode ? (
+            // 기본 캘린더 뷰
+            <div className="calendar-popup">
+              <div className="calendar-header">
+                <button className="close-btn" onClick={onBack}>×</button>
+                <div className="calendar-navigation">
+                  <button className="nav-btn" onClick={goToPreviousMonth}>‹</button>
+                  <h2>{`${displayMonth + 1}월 ${displayYear}`}</h2>
+                  <button className="nav-btn" onClick={goToNextMonth}>›</button>
+                </div>
               </div>
-                             <div className="recommended-movies">
-                 <h4>추천 영화</h4>
-                 <div className="movie-poster-placeholder">
-                   <span>영화 포스터</span>
-                 </div>
-                 <div className="movie-description">
-                   <p>영화 줄거리가 여기에 표시됩니다.</p>
-                   <p>백엔드 연동 후 실제 영화 정보가 표시될 예정입니다.</p>
-                 </div>
-               </div>
-            </div>
-
-                                      {/* 중앙 패널 - 날짜 선택 */}
-             <div className="calendar-center-panel">
-               <h3>날짜를 선택해주세요.</h3>
-               <div className="calendar-month-navigation">
-                 <button className="nav-btn" onClick={goToPreviousMonth}>‹</button>
-                 <p>{displayYear}년 {displayMonth + 1}월</p>
-                 <button className="nav-btn" onClick={goToNextMonth}>›</button>
-               </div>
-               <div className="calendar-grid">
+              <div className="calendar-grid">
                 <div className="calendar-weekdays">
                   <span>일</span>
                   <span>월</span>
@@ -275,70 +171,166 @@ const Calendar = ({ onBack }) => {
                 <div className="calendar-days">
                   {calendarDays.map((day, index) => {
                     const hasEntry = daysWithEntries.includes(day);
-                    const isSelected = day === selectedDate.getDate();
+                    const entry = hasEntry ? monthData.find(e => e.day === day) : null;
                     
                     return (
                       <div
                         key={index}
-                        className={`calendar-day ${day ? 'has-content' : 'empty'} ${isSelected ? 'selected' : ''} ${hasEntry ? 'has-entry' : ''}`}
+                        className={`calendar-day ${day ? 'has-content' : 'empty'} ${hasEntry ? 'has-mood' : ''}`}
                         onClick={() => handleDateClick(day)}
                       >
-                        {day && <span className="day-number">{day}</span>}
+                        {day && (
+                          <>
+                            <span className="day-number">{day}</span>
+                            {hasEntry && (
+                              <span className="mood-indicator">
+                                {moods.find(m => m.text === entry.mood)?.emoji || '😊'}
+                              </span>
+                            )}
+                          </>
+                        )}
                       </div>
                     );
                   })}
                 </div>
               </div>
+              <button className="edit-calendar-btn" onClick={() => setIsEditMode(true)}>
+                캘린더 수정
+              </button>
             </div>
+          ) : (
+            // 편집 모드 캘린더 뷰
+            <div className="calendar-edit-popup">
+              {/* 편집 모드에서 저장/삭제 중일 때만 로딩 오버레이 */}
+              {isLoading && (
+                <div className="loading-container" style={{
+                  position: 'absolute',
+                  top: 0,
+                  left: 0,
+                  right: 0,
+                  bottom: 0,
+                  background: 'rgba(255, 255, 255, 0.9)',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  justifyContent: 'center',
+                  alignItems: 'center',
+                  zIndex: 10,
+                  borderRadius: '12px'
+                }}>
+                  <div className="loading-spinner"></div>
+                  <p>저장 중...</p>
+                </div>
+              )}
+              <div className="calendar-edit-header">
+                <button className="back-btn" onClick={() => setIsEditMode(false)}>← 뒤로가기</button>
+                <button className="close-btn" onClick={onBack}>×</button>
+              </div>
+              <div className="calendar-edit-content">
+                {/* 왼쪽 패널 - 나만의 캘린더 */}
+                <div className="calendar-left-panel">
+                  <h3>나만의 캘린더</h3>
+                  <div className="profile-section">
+                    <div className="profile-placeholder">프로필</div>
+                  </div>
+                  <div className="recommended-movies">
+                    <h4>추천 영화</h4>
+                    <div className="movie-poster-placeholder">
+                      <span>영화 포스터</span>
+                    </div>
+                    <div className="movie-description">
+                      <p>영화 줄거리가 여기에 표시됩니다.</p>
+                      <p>백엔드 연동 후 실제 영화 정보가 표시될 예정입니다.</p>
+                    </div>
+                  </div>
+                </div>
 
-            {/* 오른쪽 패널 - 직접 수정 */}
-            <div className="calendar-right-panel">
-              <h3>직접 수정</h3>
-              <p>{formatDate(selectedDate)}</p>
-              
-              <div className="mood-selection">
-                <h4>오늘의 기분</h4>
-                <div className="mood-options">
-                  {moods.map((mood, index) => (
-                    <button
-                      key={index}
-                      className={`mood-option ${selectedMood === mood.text ? 'selected' : ''}`}
-                      onClick={() => setSelectedMood(mood.text)}
-                    >
-                      <span className="mood-emoji">{mood.emoji}</span>
-                      <span className="mood-text">{mood.text}</span>
+                {/* 중앙 패널 - 날짜 선택 */}
+                <div className="calendar-center-panel">
+                  <h3>날짜를 선택해주세요.</h3>
+                  <div className="calendar-month-navigation">
+                    <button className="nav-btn" onClick={goToPreviousMonth}>‹</button>
+                    <p>{displayYear}년 {displayMonth + 1}월</p>
+                    <button className="nav-btn" onClick={goToNextMonth}>›</button>
+                  </div>
+                  <div className="calendar-grid">
+                    <div className="calendar-weekdays">
+                      <span>일</span>
+                      <span>월</span>
+                      <span>화</span>
+                      <span>수</span>
+                      <span>목</span>
+                      <span>금</span>
+                      <span>토</span>
+                    </div>
+                    <div className="calendar-days">
+                      {calendarDays.map((day, index) => {
+                        const hasEntry = daysWithEntries.includes(day);
+                        const isSelected = day === selectedDate.getDate();
+                        
+                        return (
+                          <div
+                            key={index}
+                            className={`calendar-day ${day ? 'has-content' : 'empty'} ${isSelected ? 'selected' : ''} ${hasEntry ? 'has-entry' : ''}`}
+                            onClick={() => handleDateClick(day)}
+                          >
+                            {day && <span className="day-number">{day}</span>}
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+                </div>
+
+                {/* 오른쪽 패널 - 직접 수정 */}
+                <div className="calendar-right-panel">
+                  <h3>직접 수정</h3>
+                  <p>{formatDate(selectedDate)}</p>
+                  
+                  <div className="mood-selection">
+                    <h4>오늘의 기분</h4>
+                    <div className="mood-options">
+                      {moods.map((mood, index) => (
+                        <button
+                          key={index}
+                          className={`mood-option ${selectedMood === mood.text ? 'selected' : ''}`}
+                          onClick={() => setSelectedMood(mood.text)}
+                        >
+                          <span className="mood-emoji">{mood.emoji}</span>
+                          <span className="mood-text">{mood.text}</span>
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+
+                  <div className="notes-section">
+                    <h4>메모</h4>
+                    <textarea
+                      value={notes}
+                      onChange={(e) => setNotes(e.target.value)}
+                      placeholder="오늘은 너무 서운한 일이 있었다."
+                      className="notes-textarea"
+                    />
+                  </div>
+
+                  <div className="button-group">
+                    <button className="save-btn" onClick={handleSave} disabled={isLoading}>
+                      {isLoading ? '저장 중...' : '저장'}
                     </button>
-                  ))}
+                    {getEntryForDate(selectedDate) && (
+                      <button className="delete-btn" onClick={handleDelete} disabled={isLoading}>
+                        {isLoading ? '삭제 중...' : '삭제'}
+                      </button>
+                    )}
+                  </div>
                 </div>
               </div>
-
-              <div className="notes-section">
-                <h4>메모</h4>
-                <textarea
-                  value={notes}
-                  onChange={(e) => setNotes(e.target.value)}
-                  placeholder="오늘은 너무 서운한 일이 있었다."
-                  className="notes-textarea"
-                />
-              </div>
-
-              <div className="button-group">
-                <button className="save-btn" onClick={handleSave} disabled={isLoading}>
-                  {isLoading ? '저장 중...' : '저장'}
-                </button>
-                {getEntryForDate(selectedDate) && (
-                  <button className="delete-btn" onClick={handleDelete} disabled={isLoading}>
-                    {isLoading ? '삭제 중...' : '삭제'}
-                  </button>
-                )}
-              </div>
+              
+              <button className="edit-complete-btn" onClick={handleEditComplete}>
+                수정 완료
+              </button>
             </div>
-          </div>
-          
-          <button className="edit-complete-btn" onClick={handleEditComplete}>
-            수정 완료
-          </button>
-        </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -1,0 +1,324 @@
+import React, { useState, useEffect } from 'react';
+import { useCalendar } from '../hooks/useCalendar';
+import './Calendar.css';
+
+const Calendar = ({ onBack }) => {
+  const [isEditMode, setIsEditMode] = useState(false);
+  const [selectedDate, setSelectedDate] = useState(new Date());
+  const [selectedMood, setSelectedMood] = useState('');
+  const [notes, setNotes] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  
+  const {
+    calendarData,
+    loading,
+    error,
+    currentYear: calendarYear,
+    currentMonth: calendarMonth,
+    getEntryForDate,
+    saveEntry,
+    deleteEntry,
+    goToPreviousMonth,
+    goToNextMonth,
+    goToCurrentMonth
+  } = useCalendar();
+
+  const moods = [
+    { emoji: '😐', text: '그냥저냥' },
+    { emoji: '😠', text: '화나요' },
+    { emoji: '😊', text: '좋아요' },
+    { emoji: '😢', text: '슬퍼요' },
+    { emoji: '🤩', text: '신나요' }
+  ];
+
+  const currentDate = new Date();
+  const displayMonth = calendarMonth;
+  const displayYear = calendarYear;
+
+  // 현재 월의 첫 번째 날과 마지막 날
+  const firstDay = new Date(displayYear, displayMonth, 1);
+  const lastDay = new Date(displayYear, displayMonth + 1, 0);
+  const daysInMonth = lastDay.getDate();
+  const startingDayOfWeek = firstDay.getDay();
+
+  // 달력 그리드 생성
+  const calendarDays = [];
+  
+  // 이전 달의 마지막 날들
+  for (let i = 0; i < startingDayOfWeek; i++) {
+    calendarDays.push(null);
+  }
+  
+  // 현재 달의 날들
+  for (let i = 1; i <= daysInMonth; i++) {
+    calendarDays.push(i);
+  }
+
+  // 현재 월의 저장된 데이터 가져오기
+  const monthData = calendarData[`${displayYear}-${displayMonth}`] || [];
+  const daysWithEntries = monthData.map(entry => entry.day);
+
+  const handleDateClick = (day) => {
+    if (day) {
+      const clickedDate = new Date(displayYear, displayMonth, day);
+      setSelectedDate(clickedDate);
+      
+      // 기존 데이터가 있는지 확인
+      const existingEntry = getEntryForDate(clickedDate);
+      if (existingEntry) {
+        setSelectedMood(existingEntry.mood);
+        setNotes(existingEntry.notes || '');
+      } else {
+        setSelectedMood('');
+        setNotes('');
+      }
+      
+      setIsEditMode(true);
+    }
+  };
+
+  const handleSave = async () => {
+    if (!selectedMood) {
+      alert('기분을 선택해주세요.');
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      await saveEntry(selectedDate, selectedMood, notes);
+      alert('저장되었습니다!');
+      setIsEditMode(false);
+    } catch (error) {
+      alert('저장에 실패했습니다: ' + error.message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleEditComplete = () => {
+    setIsEditMode(false);
+  };
+
+  const handleDelete = async () => {
+    if (!window.confirm('이 날짜의 데이터를 삭제하시겠습니까?')) {
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      await deleteEntry(selectedDate);
+      alert('삭제되었습니다!');
+      setIsEditMode(false);
+    } catch (error) {
+      alert('삭제에 실패했습니다: ' + error.message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const formatDate = (date) => {
+    const months = ['1월', '2월', '3월', '4월', '5월', '6월', '7월', '8월', '9월', '10월', '11월', '12월'];
+    const days = ['일요일', '월요일', '화요일', '수요일', '목요일', '금요일', '토요일'];
+    return `${months[date.getMonth()]} ${date.getDate()}일 ${days[date.getDay()]}`;
+  };
+
+  // 로딩 상태
+  if (loading) {
+    return (
+      <div className="calendar-container">
+        <div className="calendar-popup">
+          <div className="loading-container">
+            <div className="loading-spinner"></div>
+            <p>캘린더 데이터를 불러오는 중...</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // 에러 상태
+  if (error) {
+    return (
+      <div className="calendar-container">
+        <div className="calendar-popup">
+          <div className="error-container">
+            <p className="error-message">{error}</p>
+            <button onClick={goToCurrentMonth} className="retry-button">
+              다시 시도
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="calendar-container">
+      {!isEditMode ? (
+        // 기본 캘린더 뷰
+        <div className="calendar-popup">
+          <div className="calendar-header">
+            <button className="close-btn" onClick={onBack}>×</button>
+            <div className="calendar-navigation">
+              <button className="nav-btn" onClick={goToPreviousMonth}>‹</button>
+              <h2>{`${displayMonth + 1}월 ${displayYear}`}</h2>
+              <button className="nav-btn" onClick={goToNextMonth}>›</button>
+            </div>
+          </div>
+          <div className="calendar-grid">
+            <div className="calendar-weekdays">
+              <span>일</span>
+              <span>월</span>
+              <span>화</span>
+              <span>수</span>
+              <span>목</span>
+              <span>금</span>
+              <span>토</span>
+            </div>
+            <div className="calendar-days">
+              {calendarDays.map((day, index) => {
+                const hasEntry = daysWithEntries.includes(day);
+                const entry = hasEntry ? monthData.find(e => e.day === day) : null;
+                
+                return (
+                  <div
+                    key={index}
+                    className={`calendar-day ${day ? 'has-content' : 'empty'} ${hasEntry ? 'has-mood' : ''}`}
+                    onClick={() => handleDateClick(day)}
+                  >
+                    {day && (
+                      <>
+                        <span className="day-number">{day}</span>
+                        {hasEntry && (
+                          <span className="mood-indicator">
+                            {moods.find(m => m.text === entry.mood)?.emoji || '😊'}
+                          </span>
+                        )}
+                      </>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+          <button className="edit-calendar-btn" onClick={() => setIsEditMode(true)}>
+            캘린더 수정
+          </button>
+        </div>
+      ) : (
+                 // 편집 모드 캘린더 뷰
+         <div className="calendar-edit-popup">
+           <div className="calendar-edit-header">
+             <button className="back-btn" onClick={() => setIsEditMode(false)}>← 뒤로가기</button>
+             <button className="close-btn" onClick={onBack}>×</button>
+           </div>
+          <div className="calendar-edit-content">
+            {/* 왼쪽 패널 - 나만의 캘린더 */}
+            <div className="calendar-left-panel">
+              <h3>나만의 캘린더</h3>
+              <div className="profile-section">
+                <div className="profile-placeholder">프로필</div>
+              </div>
+                             <div className="recommended-movies">
+                 <h4>추천 영화</h4>
+                 <div className="movie-poster-placeholder">
+                   <span>영화 포스터</span>
+                 </div>
+                 <div className="movie-description">
+                   <p>영화 줄거리가 여기에 표시됩니다.</p>
+                   <p>백엔드 연동 후 실제 영화 정보가 표시될 예정입니다.</p>
+                 </div>
+               </div>
+            </div>
+
+                                      {/* 중앙 패널 - 날짜 선택 */}
+             <div className="calendar-center-panel">
+               <h3>날짜를 선택해주세요.</h3>
+               <div className="calendar-month-navigation">
+                 <button className="nav-btn" onClick={goToPreviousMonth}>‹</button>
+                 <p>{displayYear}년 {displayMonth + 1}월</p>
+                 <button className="nav-btn" onClick={goToNextMonth}>›</button>
+               </div>
+               <div className="calendar-grid">
+                <div className="calendar-weekdays">
+                  <span>일</span>
+                  <span>월</span>
+                  <span>화</span>
+                  <span>수</span>
+                  <span>목</span>
+                  <span>금</span>
+                  <span>토</span>
+                </div>
+                <div className="calendar-days">
+                  {calendarDays.map((day, index) => {
+                    const hasEntry = daysWithEntries.includes(day);
+                    const isSelected = day === selectedDate.getDate();
+                    
+                    return (
+                      <div
+                        key={index}
+                        className={`calendar-day ${day ? 'has-content' : 'empty'} ${isSelected ? 'selected' : ''} ${hasEntry ? 'has-entry' : ''}`}
+                        onClick={() => handleDateClick(day)}
+                      >
+                        {day && <span className="day-number">{day}</span>}
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            </div>
+
+            {/* 오른쪽 패널 - 직접 수정 */}
+            <div className="calendar-right-panel">
+              <h3>직접 수정</h3>
+              <p>{formatDate(selectedDate)}</p>
+              
+              <div className="mood-selection">
+                <h4>오늘의 기분</h4>
+                <div className="mood-options">
+                  {moods.map((mood, index) => (
+                    <button
+                      key={index}
+                      className={`mood-option ${selectedMood === mood.text ? 'selected' : ''}`}
+                      onClick={() => setSelectedMood(mood.text)}
+                    >
+                      <span className="mood-emoji">{mood.emoji}</span>
+                      <span className="mood-text">{mood.text}</span>
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              <div className="notes-section">
+                <h4>메모</h4>
+                <textarea
+                  value={notes}
+                  onChange={(e) => setNotes(e.target.value)}
+                  placeholder="오늘은 너무 서운한 일이 있었다."
+                  className="notes-textarea"
+                />
+              </div>
+
+              <div className="button-group">
+                <button className="save-btn" onClick={handleSave} disabled={isLoading}>
+                  {isLoading ? '저장 중...' : '저장'}
+                </button>
+                {getEntryForDate(selectedDate) && (
+                  <button className="delete-btn" onClick={handleDelete} disabled={isLoading}>
+                    {isLoading ? '삭제 중...' : '삭제'}
+                  </button>
+                )}
+              </div>
+            </div>
+          </div>
+          
+          <button className="edit-complete-btn" onClick={handleEditComplete}>
+            수정 완료
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Calendar;

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -122,8 +122,11 @@ const Calendar = ({ onBack }) => {
     return `${months[date.getMonth()]} ${date.getDate()}일 ${days[date.getDay()]}`;
   };
 
-  // 로딩 상태
-  if (loading) {
+  // 로딩 상태 플래그 (데이터 조회 시에만 전역 오버레이)
+  const showGlobalLoading = loading && !isEditMode;
+  
+  // 전역 로딩 상태 (데이터 조회 시에만)
+  if (showGlobalLoading) {
     return (
       <div className="calendar-container">
         <div className="calendar-popup">
@@ -206,12 +209,32 @@ const Calendar = ({ onBack }) => {
           </button>
         </div>
       ) : (
-                 // 편집 모드 캘린더 뷰
-         <div className="calendar-edit-popup">
-           <div className="calendar-edit-header">
-             <button className="back-btn" onClick={() => setIsEditMode(false)}>← 뒤로가기</button>
-             <button className="close-btn" onClick={onBack}>×</button>
-           </div>
+        // 편집 모드 캘린더 뷰
+        <div className="calendar-edit-popup">
+          {/* 편집 모드에서 저장/삭제 중일 때만 로딩 오버레이 */}
+          {isLoading && (
+            <div className="loading-container" style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              right: 0,
+              bottom: 0,
+              background: 'rgba(255, 255, 255, 0.9)',
+              display: 'flex',
+              flexDirection: 'column',
+              justifyContent: 'center',
+              alignItems: 'center',
+              zIndex: 10,
+              borderRadius: '12px'
+            }}>
+              <div className="loading-spinner"></div>
+              <p>저장 중...</p>
+            </div>
+          )}
+          <div className="calendar-edit-header">
+            <button className="back-btn" onClick={() => setIsEditMode(false)}>← 뒤로가기</button>
+            <button className="close-btn" onClick={onBack}>×</button>
+          </div>
           <div className="calendar-edit-content">
             {/* 왼쪽 패널 - 나만의 캘린더 */}
             <div className="calendar-left-panel">

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -265,7 +265,10 @@ const Calendar = ({ onBack }) => {
                     <div className="calendar-days">
                       {calendarDays.map((day, index) => {
                         const hasEntry = daysWithEntries.includes(day);
-                        const isSelected = day === selectedDate.getDate();
+                        const isSelected = !!day
+                          && selectedDate.getFullYear() === displayYear
+                          && selectedDate.getMonth() === displayMonth
+                          && day === selectedDate.getDate();
                         
                         return (
                           <div

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { FaHome, FaSearch, FaPlus, FaCalendar } from 'react-icons/fa';
 import './Sidebar.css';
 
-const Sidebar = ({ onPlusClick, onHomeClick, currentView }) => {
+const Sidebar = ({ onPlusClick, onHomeClick, onCalendarClick, currentView }) => {
   return (
     <nav className="sidebar">
       <div className="logo-section">
@@ -40,8 +40,10 @@ const Sidebar = ({ onPlusClick, onHomeClick, currentView }) => {
         </button>
         <button 
           type="button"
-          className="nav-button" 
+          className={`nav-button ${currentView === 'calendar' ? 'active' : ''}`}
           aria-label="캘린더"
+          aria-pressed={currentView === 'calendar'}
+          onClick={onCalendarClick}
         >
           <FaCalendar className="nav-icon" aria-hidden="true" />
         </button>

--- a/src/hooks/useCalendar.js
+++ b/src/hooks/useCalendar.js
@@ -1,0 +1,188 @@
+import { useState, useEffect, useCallback } from 'react';
+import { 
+  getMonthlyCalendarData, 
+  saveMonthlyCalendarData,
+  getCalendarEntry,
+  saveCalendarEntry,
+  deleteCalendarEntry
+} from '../services/calendarService';
+
+export const useCalendar = () => {
+  const [calendarData, setCalendarData] = useState({});
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [currentYear, setCurrentYear] = useState(new Date().getFullYear());
+  const [currentMonth, setCurrentMonth] = useState(new Date().getMonth());
+
+  // 특정 월의 캘린더 데이터 로드
+  const loadCalendarData = useCallback(async (year, month) => {
+    setLoading(true);
+    setError(null);
+    
+    try {
+      const data = await getMonthlyCalendarData(year, month);
+      setCalendarData(prev => ({
+        ...prev,
+        [`${year}-${month}`]: data
+      }));
+    } catch (err) {
+      setError(err.message);
+      console.error('캘린더 데이터 로딩 실패:', err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  // 현재 월의 캘린더 데이터 로드
+  const loadCurrentMonthData = useCallback(() => {
+    loadCalendarData(currentYear, currentMonth);
+  }, [currentYear, currentMonth, loadCalendarData]);
+
+  // 특정 날짜의 데이터 가져오기
+  const getEntryForDate = useCallback((date) => {
+    const year = date.getFullYear();
+    const month = date.getMonth();
+    const day = date.getDate();
+    
+    const monthData = calendarData[`${year}-${month}`] || [];
+    return monthData.find(entry => entry.day === day);
+  }, [calendarData]);
+
+  // 캘린더 데이터 저장
+  const saveEntry = useCallback(async (date, mood, notes) => {
+    setLoading(true);
+    setError(null);
+    
+    try {
+      const year = date.getFullYear();
+      const month = date.getMonth();
+      const day = date.getDate();
+      
+      // 백엔드에 저장
+      await saveCalendarEntry(date.toISOString().split('T')[0], mood, notes);
+      
+      // 로컬 상태 업데이트
+      const monthKey = `${year}-${month}`;
+      const monthData = calendarData[monthKey] || [];
+      
+      const existingIndex = monthData.findIndex(entry => entry.day === day);
+      const newEntry = {
+        day,
+        mood,
+        notes,
+        date: date.toISOString().split('T')[0]
+      };
+      
+      let updatedMonthData;
+      if (existingIndex >= 0) {
+        // 기존 항목 수정
+        updatedMonthData = [...monthData];
+        updatedMonthData[existingIndex] = newEntry;
+      } else {
+        // 새 항목 추가
+        updatedMonthData = [...monthData, newEntry];
+      }
+      
+      // 로컬 스토리지에 저장
+      await saveMonthlyCalendarData(year, month, updatedMonthData);
+      
+      // 상태 업데이트
+      setCalendarData(prev => ({
+        ...prev,
+        [monthKey]: updatedMonthData
+      }));
+      
+      return { success: true };
+    } catch (err) {
+      setError(err.message);
+      console.error('캘린더 데이터 저장 실패:', err);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  }, [calendarData]);
+
+  // 캘린더 데이터 삭제
+  const deleteEntry = useCallback(async (date) => {
+    setLoading(true);
+    setError(null);
+    
+    try {
+      const year = date.getFullYear();
+      const month = date.getMonth();
+      const day = date.getDate();
+      
+      // 백엔드에서 삭제
+      await deleteCalendarEntry(date.toISOString().split('T')[0]);
+      
+      // 로컬 상태 업데이트
+      const monthKey = `${year}-${month}`;
+      const monthData = calendarData[monthKey] || [];
+      
+      const updatedMonthData = monthData.filter(entry => entry.day !== day);
+      
+      // 로컬 스토리지에 저장
+      await saveMonthlyCalendarData(year, month, updatedMonthData);
+      
+      // 상태 업데이트
+      setCalendarData(prev => ({
+        ...prev,
+        [monthKey]: updatedMonthData
+      }));
+      
+      return { success: true };
+    } catch (err) {
+      setError(err.message);
+      console.error('캘린더 데이터 삭제 실패:', err);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  }, [calendarData]);
+
+  // 월 변경
+  const changeMonth = useCallback((year, month) => {
+    setCurrentYear(year);
+    setCurrentMonth(month);
+    loadCalendarData(year, month);
+  }, [loadCalendarData]);
+
+  // 현재 월로 이동
+  const goToCurrentMonth = useCallback(() => {
+    const now = new Date();
+    changeMonth(now.getFullYear(), now.getMonth());
+  }, [changeMonth]);
+
+  // 이전 월로 이동
+  const goToPreviousMonth = useCallback(() => {
+    const newDate = new Date(currentYear, currentMonth - 1, 1);
+    changeMonth(newDate.getFullYear(), newDate.getMonth());
+  }, [currentYear, currentMonth, changeMonth]);
+
+  // 다음 월로 이동
+  const goToNextMonth = useCallback(() => {
+    const newDate = new Date(currentYear, currentMonth + 1, 1);
+    changeMonth(newDate.getFullYear(), newDate.getMonth());
+  }, [currentYear, currentMonth, changeMonth]);
+
+  // 컴포넌트 마운트 시 현재 월 데이터 로드
+  useEffect(() => {
+    loadCurrentMonthData();
+  }, [loadCurrentMonthData]);
+
+  return {
+    calendarData,
+    loading,
+    error,
+    currentYear,
+    currentMonth,
+    loadCalendarData,
+    getEntryForDate,
+    saveEntry,
+    deleteEntry,
+    changeMonth,
+    goToCurrentMonth,
+    goToPreviousMonth,
+    goToNextMonth
+  };
+};

--- a/src/services/calendarService.js
+++ b/src/services/calendarService.js
@@ -1,0 +1,126 @@
+import { API_BASE_URL } from '../constants/api';
+
+// 캘린더 데이터 가져오기
+export const getCalendarData = async (year, month) => {
+  try {
+    const response = await fetch(`${API_BASE_URL}/calendar?year=${year}&month=${month}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${localStorage.getItem('token')}`
+      }
+    });
+
+    if (!response.ok) {
+      throw new Error('캘린더 데이터를 불러오는데 실패했습니다.');
+    }
+
+    return await response.json();
+  } catch (error) {
+    console.error('캘린더 데이터 로딩 오류:', error);
+    throw error;
+  }
+};
+
+// 특정 날짜의 캘린더 데이터 가져오기
+export const getCalendarEntry = async (date) => {
+  try {
+    const response = await fetch(`${API_BASE_URL}/calendar/entry?date=${date}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${localStorage.getItem('token')}`
+      }
+    });
+
+    if (!response.ok) {
+      throw new Error('캘린더 항목을 불러오는데 실패했습니다.');
+    }
+
+    return await response.json();
+  } catch (error) {
+    console.error('캘린더 항목 로딩 오류:', error);
+    throw error;
+  }
+};
+
+// 캘린더 데이터 저장/수정
+export const saveCalendarEntry = async (date, mood, notes) => {
+  try {
+    const response = await fetch(`${API_BASE_URL}/calendar/entry`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${localStorage.getItem('token')}`
+      },
+      body: JSON.stringify({
+        date,
+        mood,
+        notes
+      })
+    });
+
+    if (!response.ok) {
+      throw new Error('캘린더 데이터 저장에 실패했습니다.');
+    }
+
+    return await response.json();
+  } catch (error) {
+    console.error('캘린더 데이터 저장 오류:', error);
+    throw error;
+  }
+};
+
+// 캘린더 데이터 삭제
+export const deleteCalendarEntry = async (date) => {
+  try {
+    const response = await fetch(`${API_BASE_URL}/calendar/entry?date=${date}`, {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${localStorage.getItem('token')}`
+      }
+    });
+
+    if (!response.ok) {
+      throw new Error('캘린더 데이터 삭제에 실패했습니다.');
+    }
+
+    return await response.json();
+  } catch (error) {
+    console.error('캘린더 데이터 삭제 오류:', error);
+    throw error;
+  }
+};
+
+// 월별 캘린더 데이터 가져오기 (로컬 스토리지 대체용)
+export const getMonthlyCalendarData = async (year, month) => {
+  try {
+    // 실제 백엔드 연동 전까지는 로컬 스토리지에서 데이터 가져오기
+    const storageKey = `calendar_${year}_${month}`;
+    const storedData = localStorage.getItem(storageKey);
+    
+    if (storedData) {
+      return JSON.parse(storedData);
+    }
+    
+    return [];
+  } catch (error) {
+    console.error('월별 캘린더 데이터 로딩 오류:', error);
+    return [];
+  }
+};
+
+// 캘린더 데이터 저장 (로컬 스토리지 대체용)
+export const saveMonthlyCalendarData = async (year, month, data) => {
+  try {
+    // 실제 백엔드 연동 전까지는 로컬 스토리지에 저장
+    const storageKey = `calendar_${year}_${month}`;
+    localStorage.setItem(storageKey, JSON.stringify(data));
+    
+    return { success: true };
+  } catch (error) {
+    console.error('월별 캘린더 데이터 저장 오류:', error);
+    throw error;
+  }
+};


### PR DESCRIPTION
## 📌 관련 이슈

- #13 

## 🚩 주요 변경사항

- Calendar 컴포넌트 추가: 감정 기록 및 메모 작성이 가능한 캘린더 UI 구현
- useCalendar 커스텀 훅 생성: 캘린더 데이터 상태 관리 및 월 네비게이션 로직
- calendarService 서비스 레이어 추가: 캘린더 데이터 CRUD 작업을 위한 API 통신 함수들
- App.js 라우팅 로직 수정: 캘린더 페이지로의 네비게이션 추가 (calendar 뷰 상태)
- Sidebar 컴포넌트 업데이트: 캘린더 버튼 클릭 이벤트 및 활성 상태 표시 기능 추가
- Calendar.css 스타일시트 생성: 캘린더 그리드, 편집 모드 스타일링

## 🛠️ 기술적 참고/특이사항

- 하이브리드 데이터 저장 방식: 백엔드 연동 전까지 localStorage + API 호출 구조로 구현 (추후 동기화 필요)
- 이중 모드 UI 구조: 일반 캘린더 뷰와 편집 모드를 분리하여 UX 향상
- 월별 데이터 캐싱: calendarData 객체에 year-month 키로 월별 데이터 캐싱하여 성능 최적화
- 날짜 계산 로직: 월의 첫째 날 요일 계산 및 달력 그리드 생성 알고리즘 구현
- 에러 처리: 로딩/에러 상태 처리 및 사용자 피드백 메시지 표시

## 👀 리뷰어에게 요청

- Figma에서 작업한 UI와 비교해서 괜찮은지 검토
- 컴포넌트 크기: Calendar.js가 324줄로 큰 편인 것 같은데, 특정 기능 별로 분리가 필요한지 의견
- 데이터 저장 전략: localStorage + API 이중 저장 방식의 적절성 검토 요청
- 성능 최적화: 월별 데이터 로딩 및 캐싱 전략에 대한 피드백

## 📋 후속 작업(To-Do)
<!-- 이 PR 이후 추가로 해야 할 작업, 남아있는 과제, 개선 아이디어 등을 체크리스트로 작성하세요. -->

- [ ] 백과 연동 후에 데이터가 잘 불러와 지는지 확인
- [ ] 후에 UI/UX 변경할 점이 있으면 확인 후에 수정

---

### 📝 기타

- 현재 캘린더 페이지 UI
<img width="1896" height="879" alt="image" src="https://github.com/user-attachments/assets/2831807d-67a2-4fe3-8e9b-485698cb2ad5" />
<img width="1883" height="864" alt="image" src="https://github.com/user-attachments/assets/71aafb37-0afd-4fde-8042-43c72af72efb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 사이드바에서 접근 가능한 전체 화면 캘린더 뷰 추가 및 앱 내 뷰 전환 지원
  - 월간 탐색(이전/다음/현재)과 요일/일자 그리드 표시
  - 날짜별 감정(이모지)·메모 기록, 편집(저장/삭제) 및 편집 모드 제공
  - 로딩 상태와 오류 재시도 흐름 포함

- **Style**
  - 모달형 반응형 캘린더 UI 및 편집 레이아웃 추가
  - 캘린더 버튼 활성 상태 시각화

- **Chores**
  - 월단위 데이터 캐싱 및 로컬 저장을 통한 오프라인 대체 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->