### PR TITLE
fix: 백엔드 응답 구조 수정에 따른 코드 수정

### DIFF
--- a/src/components/PhotoTicket.js
+++ b/src/components/PhotoTicket.js
@@ -18,8 +18,8 @@ const PhotoTicket = ({ entry, date, onClose }) => {
   const generateShareUrl = () => {
     const baseUrl = window.location.origin;
     
-    // 백엔드에서 받은 UUID 사용
-    const uuid = entry.id;
+    // 백엔드에서 받은 shareUuid 사용
+    const uuid = entry.shareUuid;
     console.log('공유 URL 생성:', { uuid, entry });
     
     if (!uuid) {

--- a/src/contexts/CalendarContext.js
+++ b/src/contexts/CalendarContext.js
@@ -213,6 +213,7 @@ export const CalendarProvider = ({ children }) => {
         notes: savedEntry.notes,
         date: savedEntry.date,
         id: savedEntry.id,
+        shareUuid: savedEntry.shareUuid,
         recommendations: savedEntry.recommendations,
         selectedMovie: savedEntry.selectedMovie || null
       };

--- a/src/services/calendarService.js
+++ b/src/services/calendarService.js
@@ -101,6 +101,7 @@ export const getMonthlyCalendarData = async (year, month) => {
         notes: entry.note,
         date: entry.date,
         id: entry.id,
+        shareUuid: entry.shareUuid,
         recommendations: entry.recommendations || [],
         selectedMovie: selectedMovie
       };
@@ -169,6 +170,7 @@ export const getCalendarEntry = async (date) => {
       notes: data.note,
       date: data.date,
       id: data.id,
+      shareUuid: data.shareUuid,
       recommendations: data.recommendations || [],
       selectedMovie: selectedMovie
     };
@@ -241,6 +243,7 @@ export const saveCalendarEntry = async (date, moodEmoji, note, movieData = null)
       notes: data.note,
       date: data.date,
       id: data.id,
+      shareUuid: data.shareUuid,
       recommendations: data.recommendations || [],
       selectedMovie: selectedMovie
     };
@@ -338,6 +341,7 @@ export const getSharedCalendarEntry = async (uuid) => {
       notes: data.note,
       date: data.date,
       id: data.id,
+      shareUuid: data.shareUuid,
       recommendations: data.recommendations || [],
       selectedMovie: selectedMovie
     };


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 이 PR과 연결되는 GitHub Issue 번호를 입력하세요. 예: #123 -->
- #이슈번호

## 🚩 주요 변경사항

- 백엔드 응답 구조 변경에 따른 공유 기능 수정 (id → shareUuid)
- PhotoTicket 컴포넌트에서 공유 URL 생성 시 entry.id 대신 entry.shareUuid 사용
- calendarService의 모든 API 응답 변환 함수에서 shareUuid 필드 추가
- CalendarContext에서 캘린더 데이터 저장 시 shareUuid 필드 포함
- 공유된 캘린더 엔트리 조회 시 새로운 백엔드 응답 구조 지원

## 🛠️ 기술적 참고/특이사항

- 백엔드 API 응답 구조 변경: EntryResponse에서 id 대신 shareUuid를 공유 식별자로 사용
- 하위 호환성 유지: 기존 id 필드는 그대로 유지하고 shareUuid 필드를 추가하여 기존 기능에 영향 없음
- 공유 URL 생성 로직 변경: 공유 URL 생성 시 entry.shareUuid를 사용하여 새로운 백엔드 API와 호환

## 👀 리뷰어에게 요청

- 공유 기능 테스트: 실제 공유 URL 생성 및 접근이 정상적으로 작동하는지 확인
- API 응답 구조: 백엔드 EntryResponse 구조와 프론트엔드 데이터 변환이 일치하는지 확인

## 📋 후속 작업(To-Do)

- [ ] 백엔드 API 응답 구조 최종 확인 및 검증
- [ ] 공유 기능 사용자 경험 개선 (로딩 상태, 에러 메시지 등)

---

### 📝 기타
<!-- 문서/디자인/테스트/참고자료/화면캡처 등 PR에 추가적으로 남기고 싶은 내용을 자유롭게 입력하세요. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 캘린더 항목의 공유 기능이 개선되었습니다. 공유 링크 생성 시스템이 업데이트되어 더욱 안정적이고 일관되게 작동하며, 공유 기능을 사용할 때 더 나은 경험을 얻을 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->